### PR TITLE
Use uuid v7 for identifier generation

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,10 +7,12 @@ const config: Config = {
   testMatch: ['**/*.spec.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   clearMocks: true,
-  transformIgnorePatterns: ['node_modules/(?!(uuid)/)'],
   collectCoverageFrom: ['**/*.{ts,tsx}', '!**/*.d.ts', '!**/*.spec.ts'],
   coveragePathIgnorePatterns: ['/dist/', '/node_modules/'],
   passWithNoTests: true,
+  moduleNameMapper: {
+    '^uuid$': '<rootDir>/src/test-utils/uuid-test-double.ts',
+  },
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.jest.json',

--- a/src/contexts/product-management/application/use-cases/create-product.use-case.ts
+++ b/src/contexts/product-management/application/use-cases/create-product.use-case.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
-import { randomUUID } from 'crypto';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../../../shared/di';
 import { ConflictError, ValidationError } from '../../../../shared/errors';
+import { generateUuidV7 } from '../../../../shared/utils/uuid';
 import { Product } from '../../domain/entities/product';
 import { DomainError } from '../../domain/errors/domain-error';
 import { Money } from '../../domain/value-objects/money';
@@ -35,7 +35,7 @@ export class CreateProductUseCase extends BaseUseCase<CreateProductDTO, ProductD
       }
 
       const product = Product.create({
-        id: randomUUID(),
+        id: generateUuidV7(),
         name,
         sku,
         ...(dto.description !== undefined ? { description: dto.description } : {}),

--- a/src/contexts/user-management/application/use-cases/create-user.use-case.ts
+++ b/src/contexts/user-management/application/use-cases/create-user.use-case.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
-import { randomUUID } from 'crypto';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../../../shared/di';
 import { ConflictError, ValidationError } from '../../../../shared/errors/application-error';
+import { generateUuidV7 } from '../../../../shared/utils/uuid';
 import { User } from '../../domain/entities/user';
 import { DomainError } from '../../domain/errors/domain-error';
 import { BirthDate } from '../../domain/value-objects/birth-date';
@@ -32,7 +32,7 @@ export class CreateUserUseCase {
 
       // Create user entity
       const user = User.create({
-        id: randomUUID(),
+        id: generateUuidV7(),
         fullName,
         email,
         gender,

--- a/src/shared/utils/uuid.ts
+++ b/src/shared/utils/uuid.ts
@@ -1,0 +1,17 @@
+type UuidModule = typeof import('uuid');
+
+let uuidModule: UuidModule | null = null;
+
+const loadUuidModule = (): UuidModule => {
+  if (uuidModule === null) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    uuidModule = require('uuid') as UuidModule;
+  }
+
+  return uuidModule;
+};
+
+export const generateUuidV7 = (): string => {
+  const { v7 } = loadUuidModule();
+  return v7();
+};

--- a/src/test-utils/uuid-test-double.ts
+++ b/src/test-utils/uuid-test-double.ts
@@ -1,0 +1,12 @@
+let counter = 0;
+
+const formatCounter = (value: number): string => value.toString(16).padStart(12, '0');
+
+export const v7 = (): string => {
+  counter += 1;
+  return `00000000-0000-7000-8000-${formatCounter(counter)}`;
+};
+
+export default {
+  v7,
+};


### PR DESCRIPTION
## Summary
- replace crypto.randomUUID usage in product and user creation use cases with a shared uuid v7 generator backed by the uuid package
- add a shared helper to lazily require the uuid module and expose a generateUuidV7 utility
- introduce a Jest moduleNameMapper test double for uuid v7 to keep the suite compatible with the ESM-only uuid package

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d4b80c7e7483309130684f228f2f6a