### PR TITLE
Add Grafana OTEL backend service to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ This repository is a starter kit for building context-engineered modular monolit
 4. Start the sample application with `pnpm dev` (runs `ts-node src/index.ts`).
 5. Run tests anytime with `pnpm test` or `pnpm test:watch`.
 
+### Optional: Run the observability stack
+
+Spin up the bundled OpenTelemetry backend with Docker Compose when you need
+Grafana dashboards, traces, or metrics locally:
+
+```bash
+docker compose up -d otel-lgtm
+```
+
+The stack exposes Grafana at <http://localhost:3000> (default credentials
+`admin` / `admin`) and accepts OTLP traffic on ports `4317` (gRPC) and `4318`
+(`http/protobuf`). Data is persisted in the `otel-lgtm-data` volume, so you can
+tear the container down safely with `docker compose down`.
+
 ## Available Scripts
 - `pnpm dev` – Run the entrypoint with hot reload through ts-node.
 - `pnpm test` – Execute the Jest suite in band (see `jest.config.ts`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,17 @@ services:
       POSTGRES_PASSWORD: password
     volumes:
       - pgdata:/var/lib/postgresql/data
+  otel-lgtm:
+    image: grafana/otel-lgtm:v0.11.10
+    restart: unless-stopped
+    ports:
+      - 3000:3000
+      - 4317:4317
+      - 4318:4318
+    environment:
+      GF_PATHS_DATA: /data/grafana
+    volumes:
+      - otel-lgtm-data:/data
 volumes:
   pgdata:
+  otel-lgtm-data:


### PR DESCRIPTION
## Summary
- add the grafana/otel-lgtm image to docker-compose with persistent storage and OTLP ports
- document how to start the local observability stack and what endpoints it exposes

## Testing
- python - <<'PY' ... # validate otel-lgtm ports in docker-compose
- docker compose version # unavailable in container environment

------
https://chatgpt.com/codex/tasks/task_e_68d7a1a49bf48330aad8ebe6ba831717